### PR TITLE
Fix equalizer memory leak in .

### DIFF
--- a/esp_codec/equalizer.c
+++ b/esp_codec/equalizer.c
@@ -194,7 +194,7 @@ static esp_err_t equalizer_close(audio_element_handle_t self)
     ESP_LOGD(TAG, "equalizer_close");
     equalizer_t *equalizer = (equalizer_t *)audio_element_getdata(self);
     esp_equalizer_uninit(equalizer->eq_handle);
-    if (equalizer->buf == NULL) {
+    if (equalizer->buf != NULL) {
         audio_free(equalizer->buf);
         equalizer->buf = NULL;
     }


### PR DESCRIPTION
I noticed a memory leak every time I restart the audio pipeline. The leak disappeared once I removed the equalizer from the audio pipeline. I confirmed it by wrapping the pipeline code in `heap_trace_start/heap_trace_stop`:

`
100 bytes (@ 0x3ffefcac) allocated CPU 1 ccount 0xac3fc764 caller 0x402178bc:0x40217975
0x402178bc: equalizer_open at /esp/project/esp-adf/components/esp-adf-libs/esp_codec/equalizer.c:114
0x40217975: equalizer_process at /esp/project/esp-adf/components/esp-adf-libs/esp_codec/equalizer.c:114
`

The `equalizer_close` was not deallocating the equalizer buffer.
Thx