### PR TITLE
esp_codec: use fabs instead of abs

### DIFF
--- a/esp_codec/audio_forge.c
+++ b/esp_codec/audio_forge.c
@@ -33,6 +33,7 @@
  *
  */
 
+#include <math.h>
 #include <string.h>
 #include "esp_log.h"
 #include "esp_err.h"
@@ -845,8 +846,8 @@ esp_err_t audio_forge_downmix_set_gain(audio_element_handle_t self, int *gain, i
         ESP_LOGE(TAG, "The gain is out (%d, %d) range", GAIN_MIN, GAIN_MAX);
         return ESP_ERR_INVALID_ARG;
     }
-    if ((int)(abs((gain[0] - audio_forge->downmix.source_info[index].gain[0]) * 100)) <= 5 //100 and 5 is to determine if two double numbers are equal.
-        && (int)(abs((gain[1] - audio_forge->downmix.source_info[index].gain[0]) * 100)) <= 5) {
+    if ((int)(fabs((gain[0] - audio_forge->downmix.source_info[index].gain[0]) * 100)) <= 5 //100 and 5 is to determine if two double numbers are equal.
+        && (int)(fabs((gain[1] - audio_forge->downmix.source_info[index].gain[0]) * 100)) <= 5) {
         return ESP_OK;
     }
     audio_forge->reflag |= ADUIO_FORGE_DM_RESTART;
@@ -984,7 +985,7 @@ esp_err_t audio_forge_sonic_set_speed(audio_element_handle_t self, float sonic_s
     if (!(audio_forge->component_select & AUDIO_FORGE_SELECT_SONIC)) {
         return ESP_OK;
     }
-    if ((int)(abs((sonic_speed - audio_forge->sonic_speed) * 100)) <= 5) {
+    if ((int)(fabs((sonic_speed - audio_forge->sonic_speed) * 100)) <= 5) {
         return ESP_OK;
     }
     audio_forge->reflag |= ADUIO_FORGE_SONIC_RESTART;
@@ -1009,7 +1010,7 @@ esp_err_t audio_forge_sonic_set_pitch(audio_element_handle_t self, float sonic_p
     if (!(audio_forge->component_select & AUDIO_FORGE_SELECT_SONIC)) {
         return ESP_OK;
     }
-    if ((int)(abs((sonic_pitch - audio_forge->sonic_pitch) * 100)) <= 5) {
+    if ((int)(fabs((sonic_pitch - audio_forge->sonic_pitch) * 100)) <= 5) {
         //100 and 5 is to determine if two double numbers are equal.
         return ESP_OK;
     }


### PR DESCRIPTION
This fixes the following warnings when building with IDF 5:

```
Building C object esp-idf/esp-adf-libs/CMakeFiles/__idf_esp-adf-libs.dir/esp_codec/audio_forge.c.obj/willow/deps/esp-adf/components/esp-adf-libs/esp_codec/audio_forge.c: In function 'audio_forge_downmix_set_gain': /willow/deps/esp-adf/components/esp-adf-libs/esp_codec/audio_forge.c:847:15: warning: using integer absolute value function 'abs' when argument is of floating-point type 'float' [-Wabsolute-value]
  847 |     if ((int)(abs((gain[0] - audio_forge->downmix.source_info[index].gain[0]) * 100)) <= 5 //100 and 5 is to determine if two double numbers are equal.
      |               ^~~
/willow/deps/esp-adf/components/esp-adf-libs/esp_codec/audio_forge.c:848:18: warning: using integer absolute value function 'abs' when argument is of floating-point type 'float' [-Wabsolute-value]
  848 |         && (int)(abs((gain[1] - audio_forge->downmix.source_info[index].gain[0]) * 100)) <= 5) {
      |                  ^~~
/willow/deps/esp-adf/components/esp-adf-libs/esp_codec/audio_forge.c: In function 'audio_forge_sonic_set_speed':
/willow/deps/esp-adf/components/esp-adf-libs/esp_codec/audio_forge.c:986:15: warning: using integer absolute value function 'abs' when argument is of floating-point type 'float' [-Wabsolute-value]
  986 |     if ((int)(abs((sonic_speed - audio_forge->sonic_speed) * 100)) <= 5) {
      |               ^~~
/willow/deps/esp-adf/components/esp-adf-libs/esp_codec/audio_forge.c: In function 'audio_forge_sonic_set_pitch':
/willow/deps/esp-adf/components/esp-adf-libs/esp_codec/audio_forge.c:1011:15: warning: using integer absolute value function 'abs' when argument is of floating-point type 'float' [-Wabsolute-value]
 1011 |     if ((int)(abs((sonic_pitch - audio_forge->sonic_pitch) * 100)) <= 5) {
      |               ^~~
```