### PR TITLE
Update esp_rtc.h

### DIFF
--- a/esp_media_protocols/include/esp_rtc.h
+++ b/esp_media_protocols/include/esp_rtc.h
@@ -29,6 +29,8 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
+
 typedef struct _esp_rtc_handle *esp_rtc_handle_t;
 
 /**


### PR DESCRIPTION
bool is undefined and this might not compile depending on where this file is included. Adding the include corrects those edge cases.