### PR TITLE
fix(esp_image_effects): Handle spaces in file paths to resolve compilation errors

### DIFF
--- a/esp_image_effects/CMakeLists.txt
+++ b/esp_image_effects/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(INCLUDE_DIRS "include")
-target_link_libraries(${COMPONENT_LIB}  INTERFACE "-L ${CMAKE_CURRENT_SOURCE_DIR}/lib/${CONFIG_IDF_TARGET}")
+target_link_libraries(${COMPONENT_LIB}  INTERFACE "-L \"${CMAKE_CURRENT_SOURCE_DIR}/lib/${CONFIG_IDF_TARGET}\"")
 target_link_libraries(${COMPONENT_LIB}  INTERFACE esp_image_effects)


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

This PR fixes the compilation failure that occurs when paths contain spaces. The issue was caused by file paths with spaces not being correctly escaped in CMakeLists.txt, resulting in syntax errors in the compiler command.

Error build/xiaozhi.elf.rsp file content fragment:
`  -L C:/OneDrive - MSFT/Code/xiaozhi-esp32-2.1.0/managed_components/espressif__esp_image_effects/lib/esp32c3 `
It should be:
`  -L "C:/OneDrive - MSFT/Code/xiaozhi-esp32-2.1.0/managed_components/espressif__esp_image_effects/lib/esp32c3" `

build error message e.g.
```
[2180/2182] Linking CXX executable xiaozhi.elf
FAILED: xiaozhi.elf
C:\WINDOWS\system32\cmd.exe /C "cd . && C:\Espressif\tools\riscv32-esp-elf\esp-14.2.0_20251107\riscv32-esp-elf\bin\riscv32-esp-elf-g++.exe -march=rv32imc_zicsr_zifencei -nostartfiles -march=rv32imc_zicsr_zifencei    -Wl,--cref -Wl,--defsym=IDF_TARGET_ESP32C3=0 "-Wl,--Map=C:/OneDrive - MSFT/Code/xiaozhi-esp32-2.1.0/build/xiaozhi.map" -Wl,--no-warn-rwx-segments -Wl,--orphan-handling=warn -fno-lto -Wl,--gc-sections -Wl,--warn-common -T rom.api.ld -T esp32c3.peripherals.ld -T esp32c3.rom.ld -T esp32c3.rom.api.ld -T esp32c3.rom.bt_funcs.ld -T esp32c3.rom.libgcc.ld -T esp32c3.rom.version.ld -T esp32c3.rom.ble_master.ld -T esp32c3.rom.ble_50.ld -T esp32c3.rom.ble_smp.ld -T esp32c3.rom.ble_dtm.ld -T esp32c3.rom.ble_test.ld -T esp32c3.rom.ble_scan.ld -T esp32c3.rom.eco3.ld -T esp32c3.rom.eco3_bt_funcs.ld -T esp32c3.rom.libc.ld -T esp32c3.rom.libc-suboptimal_for_misaligned_mem.ld -T esp32c3.rom.newlib.ld -T memory.ld -T sections.ld @CMakeFiles\xiaozhi.elf.rsp -o xiaozhi.elf && cd ."
riscv32-esp-elf-g++.exe: error: -E or -x required when input is from standard input
ninja: build stopped: subcommand failed.
ninja failed with exit code 1, output of the command is in the C:\OneDrive - MSFT\Code\xiaozhi-esp32-2.1.0\build\log\idf_py_stderr_output_161332 and C:\OneDrive - MSFT\Code\xiaozhi-esp32-2.1.0\build\log\idf_py_stdout_output_161332
build failed
```

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

Verified compilation succeeds with the fix applied.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
