### PR TITLE
fix: excessive float conversion warnings

### DIFF
--- a/esp_codec/audio_forge.c
+++ b/esp_codec/audio_forge.c
@@ -846,8 +846,8 @@ esp_err_t audio_forge_downmix_set_gain(audio_element_handle_t self, float *gain,
         ESP_LOGE(TAG, "The gain is out (%d, %d) range", GAIN_MIN, GAIN_MAX);
         return ESP_ERR_INVALID_ARG;
     }
-    if ((int)(fabs((gain[0] - audio_forge->downmix.source_info[index].gain[0]) * 100)) <= 5 //100 and 5 is to determine if two double numbers are equal.
-        && (int)(fabs((gain[1] - audio_forge->downmix.source_info[index].gain[0]) * 100)) <= 5) {
+    if (fabsf(gain[0] - audio_forge->downmix.source_info[index].gain[0]) <= .05f //.05 is to determine if two numbers are equal.
+        && fabsf(gain[1] - audio_forge->downmix.source_info[index].gain[0]) <= .05f) {
         return ESP_OK;
     }
     audio_forge->reflag |= ADUIO_FORGE_DM_RESTART;
@@ -985,7 +985,7 @@ esp_err_t audio_forge_sonic_set_speed(audio_element_handle_t self, float sonic_s
     if (!(audio_forge->component_select & AUDIO_FORGE_SELECT_SONIC)) {
         return ESP_OK;
     }
-    if ((int)(abs((sonic_speed - audio_forge->sonic_speed) * 100)) <= 5) {
+    if (fabsf(sonic_speed - audio_forge->sonic_speed) <= .05f) {
         return ESP_OK;
     }
     audio_forge->reflag |= ADUIO_FORGE_SONIC_RESTART;
@@ -1010,8 +1010,8 @@ esp_err_t audio_forge_sonic_set_pitch(audio_element_handle_t self, float sonic_p
     if (!(audio_forge->component_select & AUDIO_FORGE_SELECT_SONIC)) {
         return ESP_OK;
     }
-    if ((int)(abs((sonic_pitch - audio_forge->sonic_pitch) * 100)) <= 5) {
-        //100 and 5 is to determine if two double numbers are equal.
+    if (fabsf(sonic_pitch - audio_forge->sonic_pitch) <= .05f) {
+        //two pitches are close enough to consider as equal.
         return ESP_OK;
     }
     audio_forge->reflag |= ADUIO_FORGE_SONIC_RESTART;


### PR DESCRIPTION
Fix warnings of this type by doing comparison more directly:

audio_forge.c: warning: using integer absolute value function 'abs' when argument is of floating-point type 'float' [-Wabsolute-value]
988 |     if ((int)(abs((sonic_speed - audio_forge->sonic_speed) * 100)) <= 5) {
013 |     if ((int)(abs((sonic_pitch - audio_forge->sonic_pitch) * 100)) <= 5) {

xtensa-esp-elf-gcc.exe (crosstool-NG esp-14.2.0_20251107) 14.2.0

## Description

Working through building ESP-ADF example, found I cannot compile esp-codec cleanly, but we can simplify it slightly to make it better.

## Testing

!Testing not yet done!

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
