### PR TITLE
fix(esp_codec): Correct multi-character warning

### DIFF
--- a/esp_codec/audio_sonic.c
+++ b/esp_codec/audio_sonic.c
@@ -165,13 +165,13 @@ static esp_err_t sonic_open(audio_element_handle_t self)
     esp_sonic_set_quality(sonic->sonic_handle, sonic->quality);
 
 #ifdef DEBUG_SONIC_ENC_ISSUE
-    char fileName1[100] = {'//', 's', 'd', 'c', 'a', 'r', 'd', '//', 't', 'e', 's', 't', '1', '.', 'p', 'c', 'm', '\0'};
+    char fileName1[100] = {'/', 's', 'd', 'c', 'a', 'r', 'd', '/', 't', 'e', 's', 't', '1', '.', 'p', 'c', 'm', '\0'};
     inone = fopen(fileName1, "rb");
     if (!inone) {
         perror(fileName1);
         return ESP_FAIL;
     }
-    char fileName[100] = {'//', 's', 'd', 'c', 'a', 'r', 'd', '//', 't', '.', 'p', 'c', 'm', '\0'};
+    char fileName[100] = {'/', 's', 'd', 'c', 'a', 'r', 'd', '/', 't', '.', 'p', 'c', 'm', '\0'};
     outone = fopen(fileName, "w");
     if (!outone) {
         perror(fileName);

--- a/esp_codec/equalizer.c
+++ b/esp_codec/equalizer.c
@@ -178,7 +178,7 @@ static esp_err_t equalizer_open(audio_element_handle_t self)
     }
 
 #ifdef DEBUG_EQUALIZER_ENC_ISSUE
-    char fileName[100] = {'//', 's', 'd', 'c', 'a', 'r', 'd', '//', 't', 'e', 's', 't', '.', 'p', 'c', 'm', '\0'};
+    char fileName[100] = {'/', 's', 'd', 'c', 'a', 'r', 'd', '/', 't', 'e', 's', 't', '.', 'p', 'c', 'm', '\0'};
     infile = fopen(fileName, "rb");
     if (!infile) {
         perror(fileName);


### PR DESCRIPTION
## Description

Address this GCC warning/error:
error: multi-character character constant [-Werror=multichar]

## Testing

I was able to compile the example.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
